### PR TITLE
Fix bug with nans in FastAPI

### DIFF
--- a/api/english/schemas/stats_weekly.py
+++ b/api/english/schemas/stats_weekly.py
@@ -1,7 +1,8 @@
 from datetime import date, datetime
+from math import isnan
 from typing import Dict, List
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, root_validator, validator
 
 
 class OutletStatsByWeek(BaseModel):
@@ -19,6 +20,54 @@ class OutletStatsByWeek(BaseModel):
             return datetime.strptime(dateval, "%Y-%m-%d").strftime("%Y-%m-%d")
         return dateval
 
+    @root_validator
+    def _valid_percentage(cls, values):
+        """Avoid NaNs by setting them to 0.0"""
+        for key in ["perFemales", "perMales", "perUnknowns"]:
+            if isnan(values[key]):
+                values[key] = 0.0
+        return values
+
 
 class TotalStatsByWeek(BaseModel):
     outlets: Dict[str, List[OutletStatsByWeek]]
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "outlets": {
+                    "Outlet 1": [
+                        {
+                            "w_begin": "2021-12-26",
+                            "w_end": "2022-01-01",
+                            "perFemales": 0.3915470494417863,
+                            "perMales": 0.6052631578947368,
+                            "perUnknowns": 0.003189792663476874,
+                        },
+                        {
+                            "w_begin": "2022-01-02",
+                            "w_end": "2022-01-08",
+                            "perFemales": 0.39904862579281186,
+                            "perMales": 0.6004228329809725,
+                            "perUnknowns": 0.0005285412262156448,
+                        },
+                    ],
+                    "Outlet 2": [
+                        {
+                            "w_begin": "2021-12-26",
+                            "w_end": "2022-01-01",
+                            "perFemales": 0.34763636363636363,
+                            "perMales": 0.648,
+                            "perUnknowns": 0.004363636363636364,
+                        },
+                        {
+                            "w_begin": "2022-01-02",
+                            "w_end": "2022-01-08",
+                            "perFemales": 0.0,
+                            "perMales": 0.0,
+                            "perUnknowns": 0.0,
+                        },
+                    ],
+                }
+            }
+        }

--- a/api/french/schemas/stats_weekly.py
+++ b/api/french/schemas/stats_weekly.py
@@ -1,7 +1,8 @@
 from datetime import date, datetime
+from math import isnan
 from typing import Dict, List
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, root_validator, validator
 
 
 class OutletStatsByWeek(BaseModel):
@@ -19,7 +20,54 @@ class OutletStatsByWeek(BaseModel):
             return datetime.strptime(dateval, "%Y-%m-%d").strftime("%Y-%m-%d")
         return dateval
 
+    @root_validator
+    def _valid_percentage(cls, values):
+        """Avoid NaNs by setting them to 0.0"""
+        for key in ["perFemales", "perMales", "perUnknowns"]:
+            if isnan(values[key]):
+                values[key] = 0.0
+        return values
+
 
 class TotalStatsByWeek(BaseModel):
     outlets: Dict[str, List[OutletStatsByWeek]]
-    
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "outlets": {
+                    "Outlet 1": [
+                        {
+                            "w_begin": "2021-12-26",
+                            "w_end": "2022-01-01",
+                            "perFemales": 0.3915470494417863,
+                            "perMales": 0.6052631578947368,
+                            "perUnknowns": 0.003189792663476874,
+                        },
+                        {
+                            "w_begin": "2022-01-02",
+                            "w_end": "2022-01-08",
+                            "perFemales": 0.39904862579281186,
+                            "perMales": 0.6004228329809725,
+                            "perUnknowns": 0.0005285412262156448,
+                        },
+                    ],
+                    "Outlet 2": [
+                        {
+                            "w_begin": "2021-12-26",
+                            "w_end": "2022-01-01",
+                            "perFemales": 0.34763636363636363,
+                            "perMales": 0.648,
+                            "perUnknowns": 0.004363636363636364,
+                        },
+                        {
+                            "w_begin": "2022-01-02",
+                            "w_end": "2022-01-08",
+                            "perFemales": 0.0,
+                            "perMales": 0.0,
+                            "perUnknowns": 0.0,
+                        },
+                    ],
+                }
+            }
+        }


### PR DESCRIPTION
## Bug
For the `weekly_info` endpoint, in certain weeks where any of `totalFemales`, `totalMales` and `totalUnknowns` are zero, w can have a division by zero issue where a nan is generated for `perFemales`, `perMales` and `perUnknowns` fields. Because Pydantic treats `nan` as a float, this passes the data validation step and the chart doesn't render because `nan` doesn't parse to valid JSON.

This fix addresses the issue and replaces nan with zero values, as they should be.

## Docs improvement
This PR also adds better documentation for the `weekly_info` endpoint by replacing the non-descriptive `additionalProp1` key with `Outlet 1`, indicating to the reader that the key represents an outlet name, and is not just an arbitrary string.