### PR TITLE
API update

### DIFF
--- a/api/english/main.py
+++ b/api/english/main.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+from collections.abc import AsyncGenerator
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -19,7 +20,7 @@ STATIC_HTML = "tracker.html"
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> None:
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Async context manager for MongoDB connection."""
     app.mongodb_client = MongoClient(HOST, PORT, **MONGO_ARGS)
     app.connection = app.mongodb_client[DB]
@@ -32,7 +33,7 @@ async def lifespan(app: FastAPI) -> None:
 app = FastAPI(
     title="Gender Gap Tracker",
     description="RESTful API for the Gender Gap Tracker public-facing dashboard",
-    version="1.1.3",
+    version="1.1.4",
     lifespan=lifespan,
 )
 

--- a/api/english/schemas/stats_by_date.py
+++ b/api/english/schemas/stats_by_date.py
@@ -4,7 +4,7 @@ from typing import List
 from pydantic import BaseModel, Field, root_validator
 
 
-def valid_percentage(cls, values):
+def valid_percentage(_, values):
     """Avoid NaNs by setting them to 0.0"""
     for key in ["perFemales", "perMales", "perUnknowns"]:
         if isnan(values[key]):

--- a/api/french/main.py
+++ b/api/french/main.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+from collections.abc import AsyncGenerator
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -19,7 +20,7 @@ STATIC_HTML = "tracker.html"
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> None:
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Async context manager for MongoDB connection."""
     app.mongodb_client = MongoClient(HOST, PORT, **MONGO_ARGS)
     app.connection = app.mongodb_client[DB]
@@ -32,7 +33,7 @@ async def lifespan(app: FastAPI) -> None:
 app = FastAPI(
     title="Radar de Parité",
     description="RESTful API for the Radar de Parité public-facing dashboard",
-    version="1.1.3",
+    version="1.1.4",
     lifespan=lifespan,
 )
 

--- a/api/french/schemas/stats_by_date.py
+++ b/api/french/schemas/stats_by_date.py
@@ -4,7 +4,7 @@ from typing import List
 from pydantic import BaseModel, Field, root_validator
 
 
-def valid_percentage(cls, values):
+def valid_percentage(_, values):
     """Avoid NaNs by setting them to 0.0"""
     for key in ["perFemales", "perMales", "perUnknowns"]:
         if isnan(values[key]):

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,7 +2,8 @@ requests>=2.28.2
 pandas>=1.5.3,<1.6.0
 pymongo<4.0.0
 pydantic<2.0.0
-fastapi>=0.93.0,<0.94.0
+httpx>=0.23.0, <0.24.0
+fastapi>=0.94.0,<0.95.0
 gunicorn>=20.1.0,<20.2.0
 uvicorn>=0.20.0,<0.21.0
 uvloop==0.17.0


### PR DESCRIPTION
* Upgraded FastAPI to `0.94.1` to address [type hinting bug described here](https://github.com/tiangolo/fastapi/issues/9246)
* Updated `cls` object variable name in reusable root validator
* Added `httpx` dependency for `pytest`