### PR TITLE
Update README with RdP publication details and longer term info

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ We present the code and framework for two bodies of work in this repo:
 
 The GGT and RdP are automated systems that measure men and women’s voices on mainstream Canadian news outlets in real time. We analyze articles from six English outlets (for the GGT) and six French outlets (for the RdP) in Canada using Natural Language Processing (NLP), and quantify the discrepancy in proportions of men and women quoted. Our larger goals through this project are to enhance awareness of women’s portrayal in public discourse through hard evidence, and to encourage news organizations to provide a more diverse set of voices in their reporting.
 
-The Gender Gap Tracker is a collaboration between [Informed Opinions](https://informedopinions.org/), a non-profit dedicated to amplifying women’s voices in media and Simon Fraser University, through the [Discourse Processing Lab](https://www.sfu.ca/discourse-lab.html) and the [Big Data Initiative](https://www.sfu.ca/big-data/big-data-sfu).
+The Gender Gap Tracker is a collaboration between [Informed Opinions](https://informedopinions.org/), a non-profit dedicated to amplifying the voices of women and gender-diverse people in media and Simon Fraser University, through the [Discourse Processing Lab](https://www.sfu.ca/discourse-lab.html) and the [Big Data Initiative](https://www.sfu.ca/big-data/big-data-sfu).
 
 ## Publications
 1. Asr FT, Mazraeh M, Lopes A, Gautam V, Gonzales J, Rao P, Taboada M. (2021) The Gender Gap Tracker: Using Natural Language Processing to measure gender bias in media. *PLoS ONE 16(1): e0245533*. https://doi.org/10.1371/journal.pone.0245533

--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 __Status: V7.0__ (Code provided as-is; only sporadic updates expected)
 
-# The Gender Gap Tracker
+# Measuring gender bias in media
 
-This repo contains the code and framework used in our study on gender bias in the media. We present the [Gender Gap Tracker (GGT)](https://gendergaptracker.informedopinions.org/), an automated system that measures men and women’s voices on mainstream Canadian news outlets in real time. We currently process articles from seven English, and six French outlets in Canada. We analyze the rich information in these news articles using Natural Language Processing (NLP) and quantify the discrepancy in proportions of men and women quoted. Our larger goals through this project are to enhance awareness of women’s portrayal in public discourse through hard evidence, and to encourage news organizations to provide a more diverse set of voices in their reporting.
+We present the code and framework for two bodies of work in this repo:
+
+1. [The Gender Gap Tracker](https://gendergaptracker.informedopinions.org/) (GGT) for English news articles
+2. [Radar de Parité](https://radardeparite.femmesexpertes.ca/) (RdP) for French news articles
+
+The GGT and RdP are automated systems that measure men and women’s voices on mainstream Canadian news outlets in real time. We analyze articles from six English outlets (for the GGT) and six French outlets (for the RdP) in Canada using Natural Language Processing (NLP), and quantify the discrepancy in proportions of men and women quoted. Our larger goals through this project are to enhance awareness of women’s portrayal in public discourse through hard evidence, and to encourage news organizations to provide a more diverse set of voices in their reporting.
 
 The Gender Gap Tracker is a collaboration between [Informed Opinions](https://informedopinions.org/), a non-profit dedicated to amplifying women’s voices in media and Simon Fraser University, through the [Discourse Processing Lab](https://www.sfu.ca/discourse-lab.html) and the [Big Data Initiative](https://www.sfu.ca/big-data/big-data-sfu).
 
 ## Publications
 1. Asr FT, Mazraeh M, Lopes A, Gautam V, Gonzales J, Rao P, Taboada M. (2021) The Gender Gap Tracker: Using Natural Language Processing to measure gender bias in media. *PLoS ONE 16(1): e0245533*. https://doi.org/10.1371/journal.pone.0245533
 2. Rao P, Taboada M. (2021), Gender bias in the news: A scalable topic modelling and visualization framework. *Frontiers in Artificial Intelligence, 4(82)*. https://doi.org/10.3389/frai.2021.664737
+3. Soumah, V.-G., Rao, P., Eibl, P., & Taboada, M. (2023). Radar de Parité: An NLP system to measure gender representation in French news stories. *Proceedings of the Canadian Conference on Artificial Intelligence*. https://doi.org/10.21428/594757db.b6f3c89e
 
 
 ## Contributors
@@ -24,7 +30,7 @@ See [CONTRIBUTORS.md](CONTRIBUTORS.md)
 
 ## Data
 
-The data was downloaded from public and subscription websites of newspapers, under the ‘fair dealing’ provision in Canada’s Copyright Act. This means that the data can be made available (upon signing a licence agreement) **only** for non-commercial and/or research purposes.
+Both the English and French datasets were downloaded from public and subscription websites of newspapers, under the ‘fair dealing’ provision in Canada’s Copyright Act. This means that the data can be made available (upon signing a licence agreement) **only** for non-commercial and/or research purposes.
 
 ## Future directions
 
@@ -32,7 +38,7 @@ In future versions of the software, we are planning to visualize more fine-grain
 
 From a research perspective, questions of salience and space arise, i.e., whether quotes by men are presented more prominently in an article, and whether men are given more space in average (perhaps counted in number of words). More nuanced questions that involve language analysis include whether the quotes are presented differently in terms of endorsement or distance from the content of the quote (*stated* vs. *claimed*). Analyses of transitivity structure in clauses can yield further insights about the type of roles women are portrayed in, complementing some of our studies' findings via dependency analyses.
 
-We are mindful of and acknowledge the relative lack of work in NLP, topic modelling and gender equality for corpora in languages other than English. Our hope is that we are at least playing a small role here, through our analyses of Canadian French-language news whose code we share in this repo. We believe that such work will yield not only interesting methodological insights, but also reveal whether the same gender disparities we observed in our English corpus are present in French. While we are actively pursuing such additional areas of inquiry, we also invite other researchers to join in this effort!
+We are mindful of and acknowledge the relative lack of work in NLP in languages other than English. We believe that we have played at least a small role here, through our analyses in the Radar de Parité on French news articles, though there still remains a lot more to be done in this domain. Our hope is that further such work will yield not only interesting methodological insights, but also reveal larger similarities in gender disparities in other regions of the world. While we are actively pursuing such additional areas of inquiry, we also invite other researchers to join in this effort!
 
 
 ## Contact


### PR DESCRIPTION
Hi @maitetaboada, I've added the RdP publication details to the [updated README](https://github.com/sfu-discourse-lab/GenderGapTracker/blob/rdp/README.md). I've also updated the descriptions to be more generic for the longer term. Could you take a look and let me know if anything needs to be added? Thanks!